### PR TITLE
Add Java 8 to the build matrix and use this as the artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [11, 17]
+        java: [8, 11, 17]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     env:
@@ -26,6 +26,7 @@ jobs:
           ./gradlew ${{ env.gradle_commands }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
+        if: matrix.java == 8
         with:
           name: omero-pc-steward
           path: build/libs/*.jar


### PR DESCRIPTION
As this extension is currently aimed to be compatible with Java 8+, this should ensure the minimal supported JDK is being tested and used at compilation time for the release artifacts

The  JDK used at compilation time can be introspected by downloading the artifacts generated by the Pull Request and looking at the MANIFEST

```
$ unzip -qc omero-pc-steward-0.1.1-SNAPSHOT.jar META-INF/MANIFEST.MF
```